### PR TITLE
Fix descriptor with the actual dtype for the array (`float32`/`<f4`)

### DIFF
--- a/src/hextools/germ/ophyd.py
+++ b/src/hextools/germ/ophyd.py
@@ -235,7 +235,9 @@ class GeRMDetectorHDF5(GeRMDetectorBase):
 
     def describe(self):
         res = super().describe()
-        res[self.image.name].update({"shape": self.frame_shape.get().tolist()})
+        res[self.image.name].update(
+            {"shape": self.frame_shape.get().tolist(), "dtype_str": "<f4"}
+        )
         return res
 
     def trigger(self):


### PR DESCRIPTION
This is to make reading from databroker 2+/tiled w/o warnings.

The data was successfully read, as reported via https://github.com/NSLS-II-HEX/profile_collection/commit/069a23bd6fd069a0db5fcdc1916b5f30729b759a using the [`2024-1.0-py310-tiled`](https://zenodo.org/records/10548109) conda environment:
```
In [8]: for name, doc in db["8ab00260-d81f-44e4-8f53-be6adace15f8"].documents():
   ...:     nx_export_callback(name, doc)
   ...:
Exporting the nx file at 2024-02-06T20:31:20.408892
Exporting the nx file at 2024-02-06T20:31:20.408952
Exporting the nx file at 2024-02-06T20:31:20.408989
Exporting the nx file at 2024-02-06T20:31:20.409029
Exporting the nx file at 2024-02-06T20:31:20.409043
Exporting the nx file at 2024-02-06T20:31:20.409058
Exporting the nx file at 2024-02-06T20:31:20.409079
Exporting the nx file at 2024-02-06T20:31:20.409107
Exporting the nx file at 2024-02-06T20:31:20.409122
nx_filepath = '/tmp/af24f943-0d7c-4839-9464-b2d39892cbf1.nxs'
```