### PR TITLE
Update dtype of `write_dir` to be CHAR (to enable >40 symbols entries)

### DIFF
--- a/src/hextools/germ/caproto_ioc.py
+++ b/src/hextools/germ/caproto_ioc.py
@@ -54,7 +54,7 @@ class GeRMSaveIOC(PVGroup):
         value="/tmp",
         doc="The directory to write data to",
         string_encoding="utf-8",
-        report_as_string=True,
+        dtype=ChannelType.CHAR,
         max_length=255,
     )
     file_name_prefix = pvproperty(


### PR DESCRIPTION
Ready for review.