### PR TITLE
Fix MCA dtype and other Tiled/Bluesky related fixes

### DIFF
--- a/src/hextools/germ/caproto_ioc.py
+++ b/src/hextools/germ/caproto_ioc.py
@@ -116,8 +116,9 @@ class GeRMSaveIOC(PVGroup):
         await obj.parent._add_subscription("count")
 
     ### MCA ###
+    # MCA reported by the GeRM libCA IOC has type 'DBF_LONG' (np.int64 or '<i8').
     mca = pvproperty(
-        value=0, doc="Mirrored mca PV", max_length=192 * 4096, read_only=True
+        value=0, doc="Mirrored mca PV", max_length=192 * 4096, dtype=int, read_only=True
     )
 
     async def callback_mca(self, pv, response):

--- a/src/hextools/germ/export.py
+++ b/src/hextools/germ/export.py
@@ -220,7 +220,7 @@ def save_hdf5(
     data,
     group_name="/entry",
     group_path="data/data",
-    dtype="float32",
+    dtype="int64",
     mode="x",
 ):
     """The function to export the data to an HDF5 file."""

--- a/src/hextools/germ/ophyd.py
+++ b/src/hextools/germ/ophyd.py
@@ -259,7 +259,7 @@ class GeRMDetectorHDF5(GeRMDetectorBase):
     def describe(self):
         res = super().describe()
         res[self.image.name].update(
-            {"shape": self.frame_shape.get().tolist(), "dtype_str": "<f4"}
+            {"shape": self.frame_shape.get().tolist(), "dtype_numpy": "<i8"}
         )
         return res
 

--- a/src/hextools/germ/ophyd.py
+++ b/src/hextools/germ/ophyd.py
@@ -104,7 +104,7 @@ class GeRMDetectorBase(GeRMMiniClassForCaprotoIOC):
         string=True,
     )
     frame_num = Cpt(EpicsSignal, ":frame_num", kind=Kind.omitted)
-    frame_shape = Cpt(EpicsSignal, ":frame_shape", kind=Kind.config)
+    frame_shape = Cpt(EpicsSignal, ":frame_shape", kind=Kind.omitted)
     ioc_stage = Cpt(EpicsSignal, ":stage", kind=Kind.omitted)
     count = Cpt(EpicsSignal, ":count", kind=Kind.omitted, string=True)
 

--- a/src/hextools/germ/ophyd.py
+++ b/src/hextools/germ/ophyd.py
@@ -239,7 +239,7 @@ class GeRMDetectorHDF5(GeRMDetectorBase):
             mimetype="application/x-hdf5",
             uri=uri,
             data_key=self.image.name,
-            parameters={"chunk_size": 1, "path": "/entry/data/data"},
+            parameters={"chunk_size": 1, "dataset": "/entry/data/data"},
         )
 
         logger.debug(


### PR DESCRIPTION
The original GeRM libCA IOC reports the `.MCA` PV's type as `DBF_LONG`, which corresponds to `np.int64` / `<i8`.

Fixed:
- Caproto IOC side:
  - MCA dtype to be int64
  - `save_hdf5` exporting function defaults to `int64`
- Ophyd side:
  - fixed the descriptor of the data to report `dtype_numpy="<i8"`
  - make the kind of the `frame_shape` component `"omitted"` to avoid failures with bluesky's `TiledWriter`
  - use `dataset` rather than `path` in `stream_resource`